### PR TITLE
Allow using the component without children

### DIFF
--- a/BackHandler.android.js
+++ b/BackHandler.android.js
@@ -30,7 +30,7 @@ class BackHandlerAndroid extends React.Component {
   }
 
   render() {
-    return this.props.children;
+    return this.props.children || null;
   }
 }
 

--- a/BackHandler.ios.js
+++ b/BackHandler.ios.js
@@ -1,1 +1,1 @@
-export const AndroidBackHandler = ({ children }) => children;
+export const AndroidBackHandler = ({ children }) => children || null;


### PR DESCRIPTION
Hi,

Thanks for making this.
I wanted to use it without wrapping children. 

```jsx
<AndroidBackHandler onBackPress={this._onBackPressAndroid} />
```

And got the following exception:
`Unhandled JS Exception: Invariant Violation: Invariant Violation: Invariant Violation: AndroidBackHandler(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.`

Here's the fix for this use case.
