### PR TITLE
Fix backhandler not listening on first focus

### DIFF
--- a/BackHandler.android.js
+++ b/BackHandler.android.js
@@ -14,6 +14,7 @@ class BackHandlerAndroid extends React.Component {
   }
 
   componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.onBackPressed);
     this._willBlurSubscription = this.props.navigation.addListener('willBlur', payload =>
       BackHandler.removeEventListener('hardwareBackPress', this.onBackPressed)
     );

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jayli3n/react-navigation-backhandler",
+  "name": "react-navigation-backhandler-jayli3n",
   "version": "1.4.0",
   "description": "Easily handle Android back button with react-navigation",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jayli3n/react-navigation-backhandler",
-  "version": "1.3.3",
+  "version": "1.3.2",
   "description": "Easily handle Android back button with react-navigation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jayli3n/react-navigation-backhandler",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Easily handle Android back button with react-navigation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-navigation-backhandler",
-  "version": "1.3.2",
+  "name": "@jayli3n/react-navigation-backhandler",
+  "version": "1.3.3",
   "description": "Easily handle Android back button with react-navigation",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vonovak/react-navigation-backhandler.git"
+    "url": "https://github.com/jayli3n/react-navigation-backhandler.git"
   },
   "keywords": [
     "react-navigation",
@@ -22,7 +22,7 @@
   "author": "Vojtech Novak",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/vonovak/react-navigation-backhandler/issues"
+    "url": "https://github.com/jayli3n/react-navigation-backhandler/issues"
   },
-  "homepage": "https://github.com/vonovak/react-navigation-backhandler#readme"
+  "homepage": "https://github.com/jayli3n/react-navigation-backhandler#readme"
 }


### PR DESCRIPTION
This PR fixes the issue where our custom backhandler doesn't work until we re-visit the same screen.

**### Reason for this issue:**
`BackHandler.addEventListener('hardwareBackPress', this.onBackPressed)` is does not run in the `willFocus` when first mounted.