### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,5 +7,5 @@ declare module "react-navigation-backhandler" {
 
   export const AndroidBackHandler: FC<PropsWithChildren<AndroidBackHandlerProperties>>;
 
-  export function useAndroidBackHandler(onBackPress: () => boolean);
+  export function useAndroidBackHandler(onBackPress: () => boolean): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,11 @@
 declare module "react-navigation-backhandler" {
-  import { Component } from "react";
+  import { FC, PropsWithChildren } from "react";
 
   export interface AndroidBackHandlerProperties {
     onBackPress: () => boolean;
   }
 
-  export class AndroidBackHandler extends Component<
-    AndroidBackHandlerProperties
-  > {}
+  export const AndroidBackHandler: FC<PropsWithChildren<AndroidBackHandlerProperties>>;
 
   export function useAndroidBackHandler(onBackPress: () => boolean);
 }


### PR DESCRIPTION
After upgrading react-native and react in our app, we started getting TS errors for `AndroidBackHandler` component. This is because before react 18, the `Component` and `FC` types added children implicitly, but now they require setting this explicitly with `PropsWithChildren`.

I also changed the type from class to functional component, because I think it's more accurate