### PR TITLE
Remove BackHandler.removeEventListener

### DIFF
--- a/BackHandler.android.js
+++ b/BackHandler.android.js
@@ -5,9 +5,9 @@ import { useFocusEffect } from '@react-navigation/native';
 export const useAndroidBackHandler = (onBackPress) => (
   useFocusEffect((
     useCallback(() => {
-      BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
 
-      return () => BackHandler.removeEventListener('hardwareBackPress', onBackPress);
+      return () => subscription.remove();
     }, [onBackPress])
   ))
 );


### PR DESCRIPTION
After upgrading react-native to version 0.77, our app crashes on Android when using the `AndroidBackHandler` component. This is due to changes introduced in [this commit](https://github.com/facebook/react-native/commit/44d619414c1de3dbf17a421afa8dbcec7cdab025). Getting rid of `BackHandler.removeEventListener` seems to resolve the issue.